### PR TITLE
Fix global `Buffer`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { ProvidePlugin } = require("webpack")
 module.exports = class NodePolyfillPlugin {
 	apply(compiler) {
 		compiler.options.plugins.push(new ProvidePlugin({
-			Buffer: "buffer",
+			Buffer: ["buffer", "Buffer"],
 			console: "console-browserify",
 			process: "process/browser"
 		}))


### PR DESCRIPTION
The global `Buffer` object needs to be the `buffer` package's `Buffer` class, so that things like:

```js
Buffer.from([1,2,3])
```

work in Node code translated by webpack.