### PR TITLE
Don't replace global console with a polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ module.exports = class NodePolyfillPlugin {
 	apply(compiler) {
 		compiler.options.plugins.push(new ProvidePlugin({
 			Buffer: ["buffer", "Buffer"],
-			console: "console-browserify",
 			process: "process/browser"
 		}))
 


### PR DESCRIPTION
Resolves https://github.com/Richienb/node-polyfill-webpack-plugin/issues/7 the issue with compatibility with Terser Plugin 