### PR TITLE
Fix TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare namespace NodePolyfillPlugin {
 		/**
 		Aliases to skip adding. Useful if you don't want a module like `console` to be polyfilled.
 		*/
-		excludeAliases?: readonly Array<
+		excludeAliases?: ReadonlyArray<
 		| "Buffer"
 		| "console"
 		| "process"

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,8 @@
 import { Compiler } from "webpack"
 
 declare namespace NodePolyfillPlugin {
-	export interface Options {
-		/**
-		Aliases to skip adding. Useful if you don't want a module like `console` to be polyfilled.
-		*/
-		excludeAliases?: ReadonlyArray<
-		| "Buffer"
+	export type Alias =
+        | "Buffer"
 		| "console"
 		| "process"
 		| "assert"
@@ -37,7 +33,13 @@ declare namespace NodePolyfillPlugin {
 		| "util"
 		| "vm"
 		| "zlib"
-		>
+
+	
+	export interface Options {
+		/**
+		Aliases to skip adding. Useful if you don't want a module like `console` to be polyfilled.
+		*/
+		excludeAliases?: readonly Alias[]
 	}
 }
 


### PR DESCRIPTION
`readonly Array<T>` syntax raises `'readonly' type modifier is only permitted on array and tuple literal types.(1354)` error, so we should use `RadonlyArray<T>` or `readonly T[]` instead.

We can see demo at [playground](https://www.typescriptlang.org/play?ssl=1&ssc=4&pln=1&pc=86#code/PTAEHICcFMEMBMD2A7ANgT3KALugDtKALaLwCWAZmdJKGQM6goagGRFnbbTxPKixIkWOgHJe2AK55UhVJxqxUOfNHoA6ABQBGAMwBWACwBKAFC4CoAIKgAvKBgJmoq0JEAeAESxPoAD6gngBGngB8ANym5qqgAEJ2DnBIaKKa3r4BwZ7GANoAulEWhADCCQBKSc6uwuhePv6BIRFRpgDGKPTYoAAiAFxxCTnpADSNngWmIKAAkuLQAB6g9GQA5siwUjB0-EUQsVjOrDQc2IyO5MgrWgBMRtdm3TnaeQlZUe3InaAAov2l9kMfKMshMprN4Aslqt1ptCGQdjFwMUDikjuxOGckvCrppboZ7qZvjkAAwvexZIA) about this error.