### PR TITLE
refact: use require.resolve instead of bare import

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,43 +14,43 @@ module.exports = class NodePolyfillPlugin {
 
 	apply(compiler) {
 		compiler.options.plugins.push(new ProvidePlugin(excludeObjectKeys({
-			Buffer: ["buffer", "Buffer"],
-			console: "console-browserify",
-			process: "process/browser.js"
+			Buffer: [require.resolve("buffer"), "Buffer"],
+			console: require.resolve("console-browserify"),
+			process: require.resolve("process/browser.js")
 		}, this.options.excludeAliases)))
 
 		compiler.options.resolve.fallback = {
 			...excludeObjectKeys({
-				assert: "assert",
-				buffer: "buffer",
-				console: "console-browserify",
-				constants: "constants-browserify",
-				crypto: "crypto-browserify",
-				domain: "domain-browser",
-				events: "events",
-				http: "stream-http",
-				https: "https-browserify",
-				os: "os-browserify/browser.js",
-				path: "path-browserify",
-				punycode: "punycode",
-				process: "process/browser.js",
-				querystring: "querystring-es3",
-				stream: "stream-browserify",
+				assert: require.resolve("assert"),
+				buffer: require.resolve("buffer"),
+				console: require.resolve("console-browserify"),
+				constants: require.resolve("constants-browserify"),
+				crypto: require.resolve("crypto-browserify"),
+				domain: require.resolve("domain-browser"),
+				events: require.resolve("events"),
+				http: require.resolve("stream-http"),
+				https: require.resolve("https-browserify"),
+				os: require.resolve("os-browserify/browser.js"),
+				path: require.resolve("path-browserify"),
+				punycode: require.resolve("punycode"),
+				process: require.resolve("process/browser.js"),
+				querystring: require.resolve("querystring-es3"),
+				stream: require.resolve("stream-browserify"),
 				/* eslint-disable camelcase */
-				_stream_duplex: "readable-stream/duplex",
-				_stream_passthrough: "readable-stream/passthrough",
-				_stream_readable: "readable-stream/readable",
-				_stream_transform: "readable-stream/transform",
-				_stream_writable: "readable-stream/writable",
-				string_decoder: "string_decoder",
+				_stream_duplex: require.resolve("readable-stream/lib/_stream_duplex.js"),
+				_stream_passthrough: require.resolve("readable-stream/lib/_stream_passthrough.js"),
+				_stream_readable: require.resolve("readable-stream/lib/_stream_readable.js"),
+				_stream_transform: require.resolve("readable-stream/lib/_stream_transform.js"),
+				_stream_writable: require.resolve("readable-stream/lib/_stream_writable.js"),
+				string_decoder: require.resolve("string_decoder"),
 				/* eslint-enable camelcase */
-				sys: "util",
-				timers: "timers-browserify",
-				tty: "tty-browserify",
-				url: "url",
-				util: "util",
-				vm: "vm-browserify",
-				zlib: "browserify-zlib"
+				sys: require.resolve("util"),
+				timers: require.resolve("timers-browserify"),
+				tty: require.resolve("tty-browserify"),
+				url: require.resolve("url"),
+				util: require.resolve("util"),
+				vm: require.resolve("vm-browserify"),
+				zlib: require.resolve("browserify-zlib")
 			}, this.options.excludeAliases),
 			...compiler.options.resolve.fallback
 		}


### PR DESCRIPTION
### What

fixes https://github.com/Richienb/node-polyfill-webpack-plugin/issues/16

### How

use `require.resolve` instead of bare import

### Other

- [x] lint
- [x] test