### PR TITLE
Fix plugins working incorrectly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,14 @@ module.exports = class NodePolyfillPlugin {
 	}
 
 	apply(compiler) {
-		compiler.options.plugins.push(new ProvidePlugin(excludeObjectKeys({
-			Buffer: [require.resolve("buffer/"), "Buffer"],
-			console: require.resolve("console-browserify"),
-			process: require.resolve("process/browser")
-		}, this.options.excludeAliases)))
+		compiler.options.plugins.push(new ProvidePlugin({
+			...excludeObjectKeys({
+				Buffer: [require.resolve("buffer/"), "Buffer"],
+				console: require.resolve("console-browserify"),
+				process: require.resolve("process/browser")
+			}, this.options.excludeAliases),
+			...compiler.options.plugins
+		}))
 
 		compiler.options.resolve.fallback = {
 			...excludeObjectKeys({


### PR DESCRIPTION
With this change, the provided plugins work correctly. A test example: webpack 5 + adm-zip (using process without import).