### PR TITLE
Fix typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,57 +1,59 @@
 import {MergeExclusive} from 'type-fest';
 import {Compiler} from 'webpack';
 
-export type Alias =
-	| 'Buffer'
-	| 'console'
-	| 'process'
-	| 'assert'
-	| 'buffer'
-	| 'console'
-	| 'constants'
-	| 'crypto'
-	| 'domain'
-	| 'events'
-	| 'http'
-	| 'https'
-	| 'os'
-	| 'path'
-	| 'punycode'
-	| 'process'
-	| 'querystring'
-	| 'stream'
-	| '_stream_duplex'
-	| '_stream_passthrough'
-	| '_stream_readable'
-	| '_stream_transform'
-	| '_stream_writable'
-	| 'string_decoder'
-	| 'sys'
-	| 'timers'
-	| 'tty'
-	| 'url'
-	| 'util'
-	| 'vm'
-	| 'zlib';
+declare namespace NodePolyfillPlugin {
+	export type Alias =
+		| 'Buffer'
+		| 'console'
+		| 'process'
+		| 'assert'
+		| 'buffer'
+		| 'console'
+		| 'constants'
+		| 'crypto'
+		| 'domain'
+		| 'events'
+		| 'http'
+		| 'https'
+		| 'os'
+		| 'path'
+		| 'punycode'
+		| 'process'
+		| 'querystring'
+		| 'stream'
+		| '_stream_duplex'
+		| '_stream_passthrough'
+		| '_stream_readable'
+		| '_stream_transform'
+		| '_stream_writable'
+		| 'string_decoder'
+		| 'sys'
+		| 'timers'
+		| 'tty'
+		| 'url'
+		| 'util'
+		| 'vm'
+		| 'zlib';
 
-interface IncludeOptions {
-	/**
-	By default, the modules that were polyfilled in Webpack 4 are mirrored over. However, you can choose to only include certain aliases. For example, you can only have `console` polyfilled.
-	*/
-	includeAliases?: readonly Alias[];
+	interface IncludeOptions {
+		/**
+		By default, the modules that were polyfilled in Webpack 4 are mirrored over. However, you can choose to only include certain aliases. For example, you can only have `console` polyfilled.
+		*/
+		includeAliases?: readonly Alias[];
+	}
+
+	interface ExcludeOptions {
+		/**
+		By default, the modules that were polyfilled in Webpack 4 are mirrored over. However, if you don't want a module like `console` to be polyfilled you can specify alises to be skipped here.
+		*/
+		excludeAliases?: readonly Alias[];
+	}
+
+	export type Options = MergeExclusive<IncludeOptions, ExcludeOptions>;
 }
-
-interface ExcludeOptions {
-	/**
-	By default, the modules that were polyfilled in Webpack 4 are mirrored over. However, if you don't want a module like `console` to be polyfilled you can specify alises to be skipped here.
-	*/
-	excludeAliases?: readonly Alias[];
-}
-
-export type Options = MergeExclusive<IncludeOptions, ExcludeOptions>;
 
 declare class NodePolyfillPlugin {
-	constructor(options?: Options);
+	constructor(options?: NodePolyfillPlugin.Options);
 
 	apply(compiler: InstanceType<typeof Compiler>): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,14 +35,14 @@ declare namespace NodePolyfillPlugin {
 		| 'vm'
 		| 'zlib';
 
-	interface IncludeOptions {
+	export interface IncludeOptions {
 		/**
 		By default, the modules that were polyfilled in Webpack 4 are mirrored over. However, you can choose to only include certain aliases. For example, you can only have `console` polyfilled.
 		*/
 		includeAliases?: readonly Alias[];
 	}
 
-	interface ExcludeOptions {
+	export interface ExcludeOptions {
 		/**
 		By default, the modules that were polyfilled in Webpack 4 are mirrored over. However, if you don't want a module like `console` to be polyfilled you can specify alises to be skipped here.
 		*/


### PR DESCRIPTION
Fixes error:
```
node_modules/node-polyfill-webpack-plugin/index.d.ts:59:1 - error TS2309: An export assignment cannot be used in a module with other exported elements.

59 export = NodePolyfillPlugin;
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/node-polyfill-webpack-plugin/index.d.ts:59
```