### PR TITLE
Add `fs` null fallback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ declare namespace NodePolyfillPlugin {
 		| 'crypto'
 		| 'domain'
 		| 'events'
+		| 'fs'
 		| 'http'
 		| 'https'
 		| 'os'

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const defaultPolyfills = new Set([
 	'constants',
 	'crypto',
 	'events',
+	'fs',
 	'http',
 	'https',
 	'os',

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = class NodePolyfillPlugin {
 				crypto: require.resolve('crypto-browserify'),
 				domain: require.resolve('domain-browser'),
 				events: require.resolve('events/'),
+				fs: false,
 				http: require.resolve('stream-http'),
 				https: require.resolve('https-browserify'),
 				os: require.resolve('os-browserify/browser'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-polyfill-webpack-plugin",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Polyfill Node.js core modules in Webpack.",
 	"repository": "Richienb/node-polyfill-webpack-plugin",
 	"author": {

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ module.exports = {
 	// Other rules...
 	plugins: [
 		new NodePolyfillPlugin(),
-	],
+	]
 };
 ```
 
@@ -35,7 +35,7 @@ module.exports = {
 	plugins: [
 		new NodePolyfillPlugin({
 			additionalAliases: ['process', 'punycode'],
-		}),
+		})
 	]
 };
 ```
@@ -64,7 +64,7 @@ module.exports = {
 	plugins: [
 		new NodePolyfillPlugin({
 			excludeAliases: ['console'],
-		}),
+		})
 	]
 };
 ```
@@ -81,7 +81,7 @@ module.exports = {
 	plugins: [
 		new NodePolyfillPlugin({
 			additionalAliases: ['console'],
-		}),
+		})
 	]
 };
 ```
@@ -98,7 +98,7 @@ module.exports = {
 	plugins: [
 		new NodePolyfillPlugin({
 			onlyAliases: ['console'],
-		}),
+		})
 	]
 };
 ```

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,8 @@ module.exports = {
 };
 ```
 
+The `fs` module resolves to nothing because its functionality cannot replicated in the browser.
+
 ## API
 
 ### new NodePolyfillPlugin(options?)


### PR DESCRIPTION
As there is no fallback to `fs` I am adding it as `false`, as I believe all that people want is just to have these defaults so that one does not need to configure all of these fallbacks manually.
Resolves #41, #29, #32, #26.