### PR TITLE
Improve compatibility with monorepos and rspack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const {ProvidePlugin} = require('webpack');
+
 const filterObject = require('filter-obj');
 
 function createAliasFilter({includeAliases, excludeAliases}) {
@@ -24,6 +24,7 @@ module.exports = class NodePolyfillPlugin {
 	}
 
 	apply(compiler) {
+		const {ProvidePlugin} = compiler.webpack;
 		const filter = createAliasFilter(this.options);
 
 		compiler.options.plugins.push(new ProvidePlugin(filter({

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const filterObject = require('filter-obj');
 
 function createAliasFilter({includeAliases, excludeAliases}) {

--- a/index.js
+++ b/index.js
@@ -23,10 +23,9 @@ module.exports = class NodePolyfillPlugin {
 	}
 
 	apply(compiler) {
-		const {ProvidePlugin} = compiler.webpack;
 		const filter = createAliasFilter(this.options);
 
-		compiler.options.plugins.push(new ProvidePlugin(filter({
+		compiler.options.plugins.push(new compiler.webpack.ProvidePlugin(filter({
 			Buffer: [require.resolve('buffer/'), 'Buffer'],
 			console: require.resolve('console-browserify'),
 			process: require.resolve('process/browser')


### PR DESCRIPTION
Use `compiler.webpack.ProvidePlugin` instead of require webpack, this is also available way in webpack, and can compatible with rspack.

This also avoid require to wrong webpack in node_modules when using monorepo